### PR TITLE
Fixed Obsidian Destroyer

### DIFF
--- a/cards/league_of_explorers/minion_obsidian_destroyer.json
+++ b/cards/league_of_explorers/minion_obsidian_destroyer.json
@@ -5,7 +5,7 @@
 	"type": "MINION",
 	"baseAttack": 7,
 	"baseHp": 7,
-	"heroClass": "ANY",
+	"heroClass": "WARRIOR",
 	"rarity": "COMMON",
 	"description": "At the end of your turn, summon a 1/1 Scarab with Taunt.",
 	"trigger": {


### PR DESCRIPTION
Obsidian Destroyer is a warrior only card.
